### PR TITLE
Fix install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ We use the python package [great_expecations](#https://greatexpectations.io) to 
 ## Installation
 
 ### Simple
-`$ pip install -r ./requirements.txt`  
+`$ python -m pip install -r ./requirements.txt`  
 
 ### Virtualenv
 `$ python3 -m venv great-expectations-workshop`  
@@ -17,7 +17,9 @@ We use the python package [great_expecations](#https://greatexpectations.io) to 
 *MacOS/Unix:*  
 `$ source great-expectations-workshop/bin/activate`  
 
+`$ python -m pip install -r requirements.txt`
+
 ### Conda
 `$ conda create -n great-expectations-workshop pip -y`  
 `$ conda activate great-expectations-workshop`  
-`$ pip install -r requirements.txt`  
+`$ python -m pip install -r requirements.txt`  


### PR DESCRIPTION
* Instruct to use the [recommended](https://docs.python.org/3/installing/index.html#basic-usage) `python -m pip` instead of `pip`
* Add missing `$ python -m pip install -r requirements.txt` to Virtualenv section